### PR TITLE
Set custom dimensions and metrics for all additional accounts

### DIFF
--- a/src/providers/ga/angulartics2-ga.spec.ts
+++ b/src/providers/ga/angulartics2-ga.spec.ts
@@ -78,6 +78,24 @@ describe('Angulartics2GoogleAnalytics', () => {
           expect(ga).toHaveBeenCalledWith('set', 'metric1', 'test');
       })));
 
+    it('should set user properties for additional account names',
+    fakeAsync(inject([Location, Angulartics2, Angulartics2GoogleAnalytics],
+        (location: Location, angulartics2: Angulartics2, angulartics2GoogleAnalytics: Angulartics2GoogleAnalytics) => {
+          fixture = createRoot(RootCmp);
+          angulartics2.settings.ga.additionalAccountNames.push("additionalAccountName");
+          angulartics2.settings.ga.additionalAccountNames.push("additionalAccountNameTwo");
+          angulartics2.setUserProperties.next({ dimension1: 'test' });
+          advance(fixture);
+          expect(ga).toHaveBeenCalledWith('set', 'dimension1', 'test');
+          expect(ga).toHaveBeenCalledWith('additionalAccountName.set', 'dimension1', 'test');
+          expect(ga).toHaveBeenCalledWith('additionalAccountNameTwo.set', 'dimension1', 'test');
+          angulartics2.setUserProperties.next({ metric1: 'test' });
+          advance(fixture);
+          expect(ga).toHaveBeenCalledWith('set', 'metric1', 'test');
+          expect(ga).toHaveBeenCalledWith('additionalAccountName.set', 'metric1', 'test');
+          expect(ga).toHaveBeenCalledWith('additionalAccountNameTwo.set', 'metric1', 'test');
+      })));
+
   it('should track user timings',
     fakeAsync(inject([Location, Angulartics2, Angulartics2GoogleAnalytics],
         (location: Location, angulartics2: Angulartics2, angulartics2GoogleAnalytics: Angulartics2GoogleAnalytics) => {

--- a/src/providers/ga/angulartics2-ga.ts
+++ b/src/providers/ga/angulartics2-ga.ts
@@ -169,11 +169,21 @@ export class Angulartics2GoogleAnalytics {
     if (ga) {
       // add custom dimensions and metrics
       for (var idx = 1; idx <= 200; idx++) {
-        if (properties['dimension' + idx.toString()]) {
-          ga('set', 'dimension' + idx.toString(), properties['dimension' + idx.toString()]);
+        const metric = `metric${idx}`;
+        const dimension = `dimension${idx}`;
+
+        if (properties[dimension]) {
+          ga('set', dimension, properties[dimension]);
+          this.angulartics2.settings.ga.additionalAccountNames.forEach((accountName: string) => {
+            ga(`${accountName}.set`, dimension, properties[dimension]);
+          });
         }
-        if (properties['metric' + idx.toString()]) {
-          ga('set', 'metric' + idx.toString(), properties['metric' + idx.toString()]);
+
+        if (properties[metric]) {
+          ga('set', metric, properties[metric]);
+          this.angulartics2.settings.ga.additionalAccountNames.forEach((accountName: string) => {
+            ga(`${accountName}.set`, metric, properties[metric]);
+          });
         }
       }
     }


### PR DESCRIPTION
This PR adds support for sending custom dimensions to GA for every additional user account not only the main account set on the global GA instance.